### PR TITLE
Use `units_per_EM` property to scale font.

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -68,7 +68,7 @@ void destroyFont(FontHandle *font) {
 }
 
 bool getFontScale(double &output, FontHandle *font) {
-    output = font->face->units_per_EM/64.;
+    output = font->face->units_per_EM;
     return true;
 }
 
@@ -98,10 +98,16 @@ bool loadGlyph(Shape &output, FontHandle *font, int unicode, double *advance) {
     FT_Error error = FT_Load_Char(font->face, unicode, FT_LOAD_NO_SCALE);
     if (error)
         return false;
+
+    double unitsPerEm;
+    double unitScale;
+    getFontScale(unitsPerEm, font);
+    unitScale = 2048.0 / unitsPerEm;
+
     output.contours.clear();
     output.inverseYAxis = false;
     if (advance)
-        *advance = font->face->glyph->advance.x/64.;
+        *advance = unitScale * font->face->glyph->advance.x/64.;
 
     int last = -1;
     // For each contour
@@ -123,7 +129,7 @@ bool loadGlyph(Shape &output, FontHandle *font, int unicode, double *advance) {
                 round++;
             }
 
-            Point2 point(font->face->glyph->outline.points[index].x/64., font->face->glyph->outline.points[index].y/64.);
+            Point2 point(unitScale*font->face->glyph->outline.points[index].x/64., unitScale*font->face->glyph->outline.points[index].y/64.);
             PointType pointType = font->face->glyph->outline.tags[index]&1 ? PATH_POINT : font->face->glyph->outline.tags[index]&2 ? CUBIC_POINT : QUADRATIC_POINT;
 
             switch (state) {


### PR DESCRIPTION
It seems that fonts internally have a value `units per em` which determines how many `units` make up 1em. (An em being the size from max height to min bottom).

The two most common values are 1000 and 2048. To ensure that two fonts with different units per em values appear the same size when rendered this change scales all values to be based on a value of 2048 units per em.
