### PR TITLE
SVG import fixes and support

### DIFF
--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -52,14 +52,13 @@ static bool readDouble(double &output, const char *&pathDef) {
     return false;
 }
 
-static bool consumeOptionalComma(const char *&pathDef) {
+static void consumeOptionalComma(const char *&pathDef) {
     while (*pathDef == ' ') {
         ++pathDef;
     }
     if (*pathDef == ',') {
         ++pathDef;
     }
-    return true;
 }
 
 static bool buildFromPath(Shape &shape, const char *pathDef) {


### PR DESCRIPTION
* Fixes parsing when commas are used between coordinates.
* Fixes relative subpaths (the 'm' command) after 'Z' / 'z' commands.
* Reduces repetition.
* Adds support for 'S' / 's' commands.