### PR TITLE
Add point tolerance to address noisy input shapes.

### DIFF
--- a/core/Shape.cpp
+++ b/core/Shape.cpp
@@ -38,6 +38,17 @@ bool Shape::validate() const {
 
 void Shape::normalize() {
     for (std::vector<Contour>::iterator contour = contours.begin(); contour != contours.end(); ++contour) {
+        // First, erase all degenerate edges.
+        std::vector<EdgeHolder>::iterator edge_it = contour->edges.begin();
+        while( edge_it != contour->edges.end() ) {
+            if( (*edge_it)->isDegenerate() ) {
+                edge_it = contour->edges.erase(edge_it);
+            }
+            else {
+                edge_it++;
+            }
+        }
+        
         if (contour->edges.size() == 1) {
             EdgeSegment *parts[3] = { };
             contour->edges[0]->splitInThirds(parts[0], parts[1], parts[2]);

--- a/core/Shape.cpp
+++ b/core/Shape.cpp
@@ -27,7 +27,7 @@ bool Shape::validate() const {
             for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
                 if (!*edge)
                     return false;
-                if ((*edge)->point(0) != corner)
+                if (!(*edge)->point(0).same(corner) )
                     return false;
                 corner = (*edge)->point(1);
             }
@@ -37,7 +37,7 @@ bool Shape::validate() const {
 }
 
 void Shape::normalize() {
-    for (std::vector<Contour>::iterator contour = contours.begin(); contour != contours.end(); ++contour)
+    for (std::vector<Contour>::iterator contour = contours.begin(); contour != contours.end(); ++contour) {
         if (contour->edges.size() == 1) {
             EdgeSegment *parts[3] = { };
             contour->edges[0]->splitInThirds(parts[0], parts[1], parts[2]);
@@ -46,6 +46,21 @@ void Shape::normalize() {
             contour->edges.push_back(EdgeHolder(parts[1]));
             contour->edges.push_back(EdgeHolder(parts[2]));
         }
+        else {
+            
+            // Make sure that start points match end points exactly or we'll get artifacts.
+            int n = contour->edges.size();
+            for( int i = 0; i < n; i++ )
+            {
+                EdgeSegment *s1 = contour->edges[i];
+                EdgeSegment *s2 = contour->edges[(i + 1) % n];
+                if( s1->point(1) != s2->point(0) )
+                {
+                    s1->moveEndPoint(s2->point(0));
+                }
+            }
+        }
+    }
 }
 
 void Shape::bounds(double &l, double &b, double &r, double &t) const {

--- a/core/Vector2.cpp
+++ b/core/Vector2.cpp
@@ -65,6 +65,12 @@ bool Vector2::operator!=(const Vector2 &other) const {
     return x != other.x || y != other.y;
 }
 
+double Vector2::Epsilon = 0.01;
+    
+bool Vector2::same(const Vector2 &other) const {
+    return fabs(x - other.x) <= Epsilon && fabs(y - other.y) <= Epsilon;
+}
+
 Vector2 Vector2::operator+() const {
     return *this;
 }

--- a/core/Vector2.h
+++ b/core/Vector2.h
@@ -13,6 +13,8 @@ namespace msdfgen {
 */
 struct Vector2 {
 
+    static double Epsilon;
+    
     double x, y;
 
     Vector2(double val = 0);
@@ -51,6 +53,7 @@ struct Vector2 {
     Vector2 & operator/=(const Vector2 &other);
     Vector2 & operator*=(double value);
     Vector2 & operator/=(double value);
+    bool same(const Vector2 &other) const;
     /// Dot product of two vectors.
     friend double dotProduct(const Vector2 &a, const Vector2 &b);
     /// A special version of the cross product for 2D vectors (returns scalar value).

--- a/core/edge-segments.cpp
+++ b/core/edge-segments.cpp
@@ -295,5 +295,17 @@ void CubicSegment::splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeS
         point(2/3.), color);
     part3 = new CubicSegment(point(2/3.), mix(mix(p[1], p[2], 2/3.), mix(p[2], p[3], 2/3.), 2/3.), p[2] == p[3] ? p[3] : mix(p[2], p[3], 2/3.), p[3], color);
 }
+    
+bool LinearSegment::isDegenerate() const {
+    return p[0].same(p[1]);
+}
+    
+bool QuadraticSegment::isDegenerate() const {
+    return p[0].same(p[2]);
+}
+
+bool CubicSegment::isDegenerate() const {
+    return p[0].same(p[3]) && (p[0].same(p[1]) || p[2].same(p[1]));
+}
 
 }

--- a/core/edge-segments.h
+++ b/core/edge-segments.h
@@ -38,6 +38,8 @@ public:
     virtual void moveEndPoint(Point2 to) = 0;
     /// Splits the edge segments into thirds which together represent the original edge.
     virtual void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const = 0;
+    
+    virtual bool isDegenerate() const = 0;
 
 };
 
@@ -57,6 +59,8 @@ public:
     void moveStartPoint(Point2 to);
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
+    
+    bool isDegenerate() const;
 
 };
 
@@ -77,6 +81,8 @@ public:
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
+    bool isDegenerate() const;
+
 };
 
 /// A cubic Bezier curve.
@@ -95,6 +101,8 @@ public:
     void moveStartPoint(Point2 to);
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
+
+    bool isDegenerate() const;
 
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -322,6 +322,8 @@ static const char *helpText =
         "\tRenders an image preview using the generated distance field and saves it as a PNG file.\n"
     "  -testrendermulti <filename.png> <width> <height>\n"
         "\tRenders an image preview without flattening the color channels.\n"
+    "  -tolerance <tolerance>  (Default: 0.01)\n"
+    	"\tTolerance when checking for point equality. Helps avoid artifacts in noisy/inaccurate input shapes.\n"
     "  -translate <x> <y>\n"
         "\tSets the translation of the shape in shape units.\n"
     "  -reverseorder\n"
@@ -600,6 +602,12 @@ int main(int argc, const char * const *argv) {
                 ABORT("Invalid seed. Use -seed <N> with N being a non-negative integer.");
             argPos += 2;
             continue;
+        }
+        ARG_CASE("-tolerance", 1) {
+        	if (!parseDouble(Vector2::Epsilon, argv[argPos+1]) || Vector2::Epsilon < 0 )
+        		ABORT("Invalid Tolerance value. Use -tolerance <N> with a value >= 0.0.");
+        	argPos += 2;
+        	continue;
         }
         ARG_CASE("-help", 0)
             ABORT(helpText);


### PR DESCRIPTION
I'm finding a lot of artifacts in various shapes I'm trying to use, and almost all seem to be hand-drawn elements with visually imperceptible precision issues (causing overlaps, etc). To address this, I've added a point tolerance that will treat points within a given distance as the same, and then snap them during normalization. This fixes almost all the issues I'm encountering.

For example (the map is easy to see):
![map-before](https://cloud.githubusercontent.com/assets/826657/26646346/17964430-45f0-11e7-9a45-dbefd76743b9.png)
![map-after](https://cloud.githubusercontent.com/assets/826657/26646351/1a7fad4e-45f0-11e7-88db-90f018b136b8.png)

On this one, notice the artifact near the top:
![abstract-before](https://cloud.githubusercontent.com/assets/826657/26646366/2aa057d2-45f0-11e7-9dec-b8bb0daac53c.png)
![abstract-after](https://cloud.githubusercontent.com/assets/826657/26646368/2c5e06be-45f0-11e7-92b2-0cd334425dbc.png)

I've also added a `-tolerance` command line option to disable (or increase) as needed.

I'm not sure how much this will help with situations like https://github.com/Chlumsky/msdfgen/issues/40, but it should help at least a little.