### PR TITLE
Return proper abort code when failing in standalone.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -333,7 +333,7 @@ static const char *helpText =
     "\n";
 
 int main(int argc, const char * const *argv) {
-    #define ABORT(msg) { puts(msg); return 0; }
+    #define ABORT(msg) { puts(msg); return 1; }
 
     // Parse command line arguments
     enum {


### PR DESCRIPTION
Returning non-zero on failure is standard and allows the condition to be checked in build scripts and other command line utilities.