### PR TITLE
Improvements to CMake IDE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ function(folderize_sources sources prefix)
 
 	  # skip src or include and changes /'s to \\'s
 	  string(REPLACE "${prefix}" "" GROUP "${PARENT_DIR}")
-	  string(REGEX REPLACE "(\\./)?(src|include)/?" "" GROUP "${GROUP}")
 	  string(REPLACE "/" "\\" GROUP "${GROUP}")
 
       # If it's got a path, then append a "\\" separator (otherwise leave it blank)
@@ -52,7 +51,9 @@ endfunction(folderize_sources)
 file(GLOB_RECURSE msdfgen_HEADERS
 	"core/*.h"
 	"lib/*.h"
-	"ext/*.h")
+	"ext/*.h"
+	"include/*.h"
+)
 
 file(GLOB_RECURSE msdfgen_SOURCES
 	"core/*.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,35 @@ endif()
 #	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 #endif()
 
+#----------------------------------------------------------------
+# Support Functions
+#----------------------------------------------------------------
+
+# Mirror the folder structure for sources inside the IDE...
+function(folderize_sources sources prefix)
+	foreach(FILE ${${sources}}) 
+	  get_filename_component(PARENT_DIR "${FILE}" PATH)
+
+	  # skip src or include and changes /'s to \\'s
+	  string(REPLACE "${prefix}" "" GROUP "${PARENT_DIR}")
+	  string(REGEX REPLACE "(\\./)?(src|include)/?" "" GROUP "${GROUP}")
+	  string(REPLACE "/" "\\" GROUP "${GROUP}")
+
+      # If it's got a path, then append a "\\" separator (otherwise leave it blank)
+	  if ("${GROUP}" MATCHES ".+")
+	  	set(GROUP "\\${GROUP}")
+	  endif()
+
+	  source_group("${GROUP}" FILES "${FILE}")
+	endforeach()
+endfunction(folderize_sources)
+
+
+
+file(GLOB_RECURSE msdfgen_HEADERS
+	"core/*.h"
+	"lib/*.h"
+	"ext/*.h")
 
 file(GLOB_RECURSE msdfgen_SOURCES
 	"core/*.cpp"
@@ -35,8 +64,10 @@ include_directories(${FREETYPE_INCLUDE_DIRS})
 include_directories("include")
 
 # Build the library (aliased name because it's the same target name the exe)
+folderize_sources(msdfgen_HEADERS ${CMAKE_SOURCE_DIR})
+folderize_sources(msdfgen_SOURCES ${CMAKE_SOURCE_DIR})
 
-add_library(lib_msdfgen ${msdfgen_SOURCES})
+add_library(lib_msdfgen ${msdfgen_SOURCES} ${msdfgen_HEADERS})
 set_target_properties(lib_msdfgen PROPERTIES OUTPUT_NAME msdfgen)
 target_link_libraries(lib_msdfgen ${FREETYPE_LIBRARIES})
 


### PR DESCRIPTION
While the previous implementation works to build, it's not that pretty when trying to debug the project in IDE (in my case, Xcode). This adds the headers and mirrors the folder structure in the IDE to make it easy to navigate. No actual code compilation changes.