### PR TITLE
Gracefully close out contours when they implicitly end

### DIFF
--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -10,7 +10,12 @@
 
 namespace msdfgen {
 
+#if NDEBUG
 #define REQUIRE(cond) { if (!(cond)) return false; }
+#else
+#define REQUIRE(cond) { if (!(cond)) { fprintf(stderr, "SVG Parse Error (%s:%d): " #cond "\n", __FILE__, __LINE__); return false; } }
+#endif
+
 
 static bool readNodeType(char &output, const char *&pathDef) {
     int shift;

--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -17,10 +17,11 @@ namespace msdfgen {
 #endif
 
 
-static bool readNodeType(char &output, const char *&pathDef) {
+static bool readNodeType(char &output, bool &haveInput, const char *&pathDef) {
     int shift;
     char nodeType;
-    if (sscanf(pathDef, " %c%n", &nodeType, &shift) == 1 && nodeType != '+' && nodeType != '-' && nodeType != '.' && nodeType != ',' && (nodeType < '0' || nodeType > '9')) {
+    haveInput = sscanf(pathDef, " %c%n", &nodeType, &shift) == 1;
+    if ( haveInput && nodeType != '+' && nodeType != '-' && nodeType != '.' && nodeType != ',' && (nodeType < '0' || nodeType > '9')) {
         pathDef += shift;
         output = nodeType;
         return true;
@@ -67,7 +68,8 @@ static void consumeOptionalComma(const char *&pathDef) {
 static bool buildFromPath(Shape &shape, const char *pathDef) {
     char nodeType;
     Point2 prevNode(0, 0);
-    while (readNodeType(nodeType, pathDef)) {
+    bool haveInput = pathDef && *pathDef;
+    while (haveInput && readNodeType(nodeType, haveInput, pathDef)) {
         Contour &contour = shape.addContour();
         bool contourStart = true;
 
@@ -75,7 +77,7 @@ static bool buildFromPath(Shape &shape, const char *pathDef) {
         Point2 controlPoint[2];
         Point2 node;
 
-        while (*pathDef) {
+        while (haveInput) {
             switch (nodeType) {
                 case 'M': case 'm':
                     REQUIRE(contourStart);
@@ -149,7 +151,7 @@ static bool buildFromPath(Shape &shape, const char *pathDef) {
             }
             contourStart &= nodeType == 'M' || nodeType == 'm';
             prevNode = node;
-            readNodeType(nodeType, pathDef);
+            readNodeType(nodeType, haveInput, pathDef);
         }
     NEXT_CONTOUR:;
     }

--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -70,6 +70,7 @@ static bool buildFromPath(Shape &shape, const char *pathDef) {
     Point2 prevNode(0, 0);
     bool haveInput = pathDef && *pathDef;
     while (haveInput && readNodeType(nodeType, haveInput, pathDef)) {
+IMPLICIT_NEXT_CONTOUR:
         Contour &contour = shape.addContour();
         bool contourStart = true;
 
@@ -80,7 +81,10 @@ static bool buildFromPath(Shape &shape, const char *pathDef) {
         while (haveInput) {
             switch (nodeType) {
                 case 'M': case 'm':
-                    REQUIRE(contourStart);
+                    // Have to use a goto here because you can't change a reference once it's
+                    // been assigned. However, jumping to the start of the block re-initializes it.
+                    if (!contourStart)
+                        goto IMPLICIT_NEXT_CONTOUR;
                     REQUIRE(readCoord(node, pathDef));
                     if (nodeType == 'm')
                         node += prevNode;

--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -70,7 +70,7 @@ static bool buildFromPath(Shape &shape, const char *pathDef) {
         Point2 controlPoint[2];
         Point2 node;
 
-        while (true) {
+        while (*pathDef) {
             switch (nodeType) {
                 case 'M': case 'm':
                     REQUIRE(contourStart);


### PR DESCRIPTION
Rather than fail to parse entirely, when encountering end of input, simply end the current contour.
 (Some shapes omit a trailing 'Z' command.) Also, because I'm tracking down a fair number of these, I spit out a bit more info on where it fails in the parse code when in debug mode.

Fixes parse issue with: http://game-icons.net/icons/various-artists/public-domain/svg/infinity.svg 

<img src="http://game-icons.net/icons/various-artists/public-domain/svg/infinity.svg" width="256" height="256"/>