### PR TITLE
Fill rule support

### DIFF
--- a/core/Shape.cpp
+++ b/core/Shape.cpp
@@ -3,7 +3,7 @@
 
 namespace msdfgen {
 
-Shape::Shape() : inverseYAxis(false) { }
+Shape::Shape() : inverseYAxis(false), fillRule(FillRule::NonZero) { }
 
 void Shape::addContour(const Contour &contour) {
     contours.push_back(contour);

--- a/core/Shape.h
+++ b/core/Shape.h
@@ -5,6 +5,13 @@
 #include "Contour.h"
 
 namespace msdfgen {
+    
+    /// Fill rules compatible with SVG: https://www.w3.org/TR/SVG/painting.html#FillRuleProperty
+    enum FillRule {
+        None = 0, // Legacy
+        NonZero = 1,
+        EvenOdd = 2,
+    };
 
 /// Vector shape representation.
 class Shape {
@@ -14,6 +21,9 @@ public:
     std::vector<Contour> contours;
     /// Specifies whether the shape uses bottom-to-top (false) or top-to-bottom (true) Y coordinates.
     bool inverseYAxis;
+    /// Fill rule for this shape.
+    FillRule fillRule;
+    
 
     Shape();
     /// Adds a contour.

--- a/core/edge-segments.cpp
+++ b/core/edge-segments.cpp
@@ -296,4 +296,103 @@ void CubicSegment::splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeS
     part3 = new CubicSegment(point(2/3.), mix(mix(p[1], p[2], 2/3.), mix(p[2], p[3], 2/3.), 2/3.), p[2] == p[3] ? p[3] : mix(p[2], p[3], 2/3.), p[3], color);
 }
 
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = intersection increasing in the Y axis
+/// -1 = intersection decreasing in the Y axis
+static int crossLine(const Point2& r, const Point2& p0, const Point2& p1, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, p1.y))
+        return 0;
+    if (r.y >= max(p0.y, p1.y))
+        return 0;
+    if (r.x >= max(p0.x, p1.x))
+        return 0;
+    // Intersect the line at r.y and see if the intersection is before or after the origin.
+    int xintercept = (p0.x + (r.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y));
+    if (r.x < xintercept) {
+        int w = (p0.y < p1.y) ? 1 : -1;
+        if( cb != NULL ) {
+            cb->intersection(Point2(xintercept, r.y), w);
+        }
+        return w;
+    }
+    return 0;
+}
+
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = for each intersection increasing in the Y axis
+/// -1 = for each intersection decreasing in the Y axis
+static int crossQuad(const Point2& r, const Point2& p0, const Point2& c0, const Point2& p1, int depth, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, min(c0.y, p1.y)))
+        return 0;
+    if (r.y > max(p0.y, max(c0.y, p1.y)))
+        return 0;
+    if (r.x >= max(p0.x, max(c0.x, p1.x)))
+        return 0;
+
+    // Recursively subdivide the curve to find the intersection point(s). If we haven't
+    // converged on a solution by a given depth, just treat it as a linear segment
+    // and call the approximation good enough.
+    if( depth > 30 )
+        return crossLine(r, p0, p1, cb);
+
+    depth++;
+
+    Point2 mc0 = (p0 + c0) * 0.5;
+    Point2 mc1 = (c0 + p1) * 0.5;
+    Point2 mid = (mc0 + mc1) * 0.5;
+
+    return crossQuad(r, p0, mc0, mid, depth, cb) + crossQuad(r, mid, mc1, p1, depth, cb);
+}
+
+/// Check how many times a ray from point R extending to the +X direction intersects
+/// the given segment:
+///  0 = no intersection or co-linear
+/// +1 = for each intersection increasing in the Y axis
+/// -1 = for each intersection decreasing in the Y axis
+static int crossCubic(const Point2& r, const Point2& p0, const Point2& c0, const Point2& c1, const Point2& p1, int depth, EdgeSegment::CrossingCallback* cb) {
+    if (r.y < min(p0.y, min(c0.y, min(c1.y, p1.y))))
+        return 0;
+    if (r.y > max(p0.y, max(c0.y, max(c1.y, p1.y))))
+        return 0;
+    if (r.x >= max(p0.x, max(c0.x, max(c1.x, p1.x))))
+        return 0;
+    
+    // Recursively subdivide the curve to find the intersection point(s). If we haven't
+    // converged on a solution by a given depth, just treat it as a linear segment
+    // and call the approximation good enough.
+    if( depth > 30 )
+        return crossLine(r, p0, p1, cb);
+    
+    depth++;
+    
+    Point2 mid = (c0 + c1) * 0.5;
+    Point2 c00 = (p0 + c0) * 0.5;
+    Point2 c11 = (c1 + p1) * 0.5;
+    Point2 c01 = (c00 + mid) * 0.5;
+    Point2 c10 = (c11 + mid) * 0.5;
+    
+    mid = (c01 + c10) * 0.5;
+    
+    return crossCubic(r, p0, c00, c01, mid, depth, cb) + crossCubic(r, mid, c10, c11, p1, depth, cb);
+}
+    
+    
+int LinearSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossLine(r, p[0], p[1], cb);
+}
+
+    
+int QuadraticSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossQuad(r, p[0], p[1], p[2], 0, cb);
+}
+
+    
+int CubicSegment::crossings(const Point2 &r, CrossingCallback* cb) const {
+    return crossCubic(r, p[0], p[1], p[2], p[3], 0, cb);
+}
+    
 }

--- a/core/edge-segments.cpp
+++ b/core/edge-segments.cpp
@@ -309,7 +309,7 @@ static int crossLine(const Point2& r, const Point2& p0, const Point2& p1, EdgeSe
     if (r.x >= max(p0.x, p1.x))
         return 0;
     // Intersect the line at r.y and see if the intersection is before or after the origin.
-    int xintercept = (p0.x + (r.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y));
+    double xintercept = (p0.x + (r.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y));
     if (r.x < xintercept) {
         int w = (p0.y < p1.y) ? 1 : -1;
         if( cb != NULL ) {

--- a/core/edge-segments.h
+++ b/core/edge-segments.h
@@ -39,6 +39,25 @@ public:
     /// Splits the edge segments into thirds which together represent the original edge.
     virtual void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const = 0;
 
+    
+    
+    class CrossingCallback {
+    public:
+        virtual ~CrossingCallback() {}
+        /// Callback for receiving intersection points. Winding is either:
+        /// +1 if the segment is increasing in the Y axis
+        /// -1 if the segment is decreasing in the Y axis
+        virtual void intersection(const Point2& p, int winding) = 0;
+    };
+    
+    /// Calculate how many times the segment intersects the infinite ray that extends
+    /// to the right (+X) from the given point. Returns:
+    ///  0 for no intersection (or co-linear)
+    /// +1 for each intersection where Y is increasing
+    /// -1 for each intersection where Y is decreasing.
+    virtual int crossings(const Point2 &r, CrossingCallback *cb = NULL) const = 0;
+    
+    
 };
 
 /// A line segment.
@@ -58,6 +77,7 @@ public:
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
 };
 
 /// A quadratic Bezier curve.
@@ -77,6 +97,7 @@ public:
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
 };
 
 /// A cubic Bezier curve.
@@ -96,6 +117,7 @@ public:
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
+    int crossings(const Point2 &r, CrossingCallback *cb = NULL) const;
 };
 
 }

--- a/core/msdfgen.cpp
+++ b/core/msdfgen.cpp
@@ -135,6 +135,8 @@ void generateSDF(Bitmap<float> &output, const Shape &shape, double range, const 
     int w = output.width(), h = output.height();
     
     WindingSpanner spanner;
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t);
     
 #ifdef MSDFGEN_USE_OPENMP
 #pragma omp parallel
@@ -147,7 +149,7 @@ void generateSDF(Bitmap<float> &output, const Shape &shape, double range, const 
             int row = shape.inverseYAxis ? h-y-1 : y;
             
             // Start slightly off the -X edge so we ensure we find all spans.
-            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
             
             for (int x = 0; x < w; ++x) {
                 Point2 p = Vector2(x+.5, y+.5)/scale-translate;
@@ -176,6 +178,8 @@ void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, 
     int w = output.width(), h = output.height();
     
     WindingSpanner spanner;
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t);
     
 #ifdef MSDFGEN_USE_OPENMP
 #pragma omp parallel
@@ -188,7 +192,7 @@ void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, 
             int row = shape.inverseYAxis ? h-y-1 : y;
             
             // Start slightly off the -X edge so we ensure we find all spans.
-            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
 
             for (int x = 0; x < w; ++x) {
                 Point2 p = Vector2(x+.5, y+.5)/scale-translate;
@@ -225,10 +229,8 @@ void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, co
     int w = output.width(), h = output.height();
     
     WindingSpanner spanner;
-    std::vector<int> windings;
-    windings.reserve(contourCount);
-    for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
-        windings.push_back(contour->winding());
+    double bound_l, bound_t, bound_b, bound_r;
+    shape.bounds(bound_l, bound_b, bound_r, bound_t);
     
 #ifdef MSDFGEN_USE_OPENMP
 #pragma omp parallel
@@ -243,7 +245,7 @@ void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, co
             int row = shape.inverseYAxis ? h-y-1 : y;
             
             // Start slightly off the -X edge so we ensure we find all spans.
-            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+            spanner.collect(shape, Vector2(bound_l - 0.5, (y + 0.5)/scale.y - translate.y));
             
             for (int x = 0; x < w; ++x) {
                 Point2 p = Vector2(x+.5, y+.5)/scale-translate;

--- a/core/msdfgen.cpp
+++ b/core/msdfgen.cpp
@@ -61,8 +61,274 @@ void msdfErrorCorrection(Bitmap<FloatRGB> &output, const Vector2 &threshold) {
         pixel.r = med, pixel.g = med, pixel.b = med;
     }
 }
+    
+/// A utility structure for holding winding spans for a single horizontal scanline.
+/// First initialize a row by calling collect(), then use advance() to walk the row
+/// and determine "inside"-ness as you go.
+struct WindingSpanner: public EdgeSegment::CrossingCallback {
+    
+    std::vector<std::pair<double, int>> crossings;
+    
+    FillRule fillRule;
+    
+    WindingSpanner(): curW(0) {
+        curSpan = crossings.cend();
+    }
+    
+    void collect(const Shape& shape, const Point2& p) {
+        fillRule = shape.fillRule;
+        crossings.clear();
+        for (std::vector<Contour>::const_iterator contour = shape.contours.cbegin(); contour != shape.contours.cend(); ++contour) {
+            for (std::vector<EdgeHolder>::const_iterator e = contour->edges.cbegin(); e != contour->edges.cend(); ++e) {
+                (*e)->crossings(p, this);
+            }
+        }
+        
+        // Make sure we've collected them all in increasing x order.
+        std::sort(crossings.begin(), crossings.end(), compareX);
+        
+        // And set up a traversal.
+        if( fillRule == FillRule::EvenOdd )
+            curW = 1;
+        else
+            curW = 0;
+        curSpan = crossings.cbegin();
+    }
+    
+    /// Scan to the provided X coordinate and use the winding rule to return the current sign as either:
+    /// -1 = pixel is "outside" the shape (i.e. not filled)
+    /// +1 = pixel is "inside" the shape (i.e. filled)
+    /// (Note: This is actually the inverse of the final distance field sign.)
+    int advanceTo(double x) {
+        while( curSpan != crossings.cend() && x > curSpan->first ) {
+            curW += curSpan->second;
+            ++curSpan;
+        }
 
+        switch( fillRule ) {
+            case FillRule::NonZero:
+                return curW != 0 ? 1 : -1;
+            case FillRule::EvenOdd:
+                return curW % 2 == 0 ? 1 : -1;
+            case FillRule::None:
+                return curSpan != crossings.cend() ? sign(curSpan->second) : 0;
+        }
+    }
+    
+private:
+
+    int curW;
+    
+    std::vector<std::pair<double, int>>::const_iterator curSpan;
+    
+    void intersection(const Point2& p, int winding) {
+        crossings.push_back(std::pair<double, int>(p.x, winding));
+    }
+
+    static bool compareX(const std::pair<double,int>& a, std::pair<double,int>& b) {
+        return a.first < b.first;
+    }
+};
+    
 void generateSDF(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    
+    WindingSpanner spanner;
+    
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+            
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                double minDistance = INFINITY;
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double dummy;
+                        double distance = fabs((*edge)->signedDistance(p, dummy).distance);
+                        if (distance < minDistance)
+                            minDistance = distance;
+                    }
+                }
+                
+                minDistance *= spanner.advanceTo(p.x);
+                output(x, row) = float(minDistance / range + 0.5);
+            }
+        }
+    }
+}
+
+void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    
+    WindingSpanner spanner;
+    
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                SignedDistance sd = SignedDistance::INFINITE;
+                const EdgeHolder *nearEdge = NULL;
+                double nearParam = 0;
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if (distance < sd) {
+                            sd = distance;
+                            nearEdge = &*edge;
+                            nearParam = param;
+                        }
+                    }
+                }
+                
+                if (nearEdge)
+                    (*nearEdge)->distanceToPseudoDistance(sd, p, nearParam);
+                
+                double d = fabs(sd.distance) * spanner.advanceTo(p.x);
+                output(x, row) = float(d / range + 0.5);
+            }
+        }
+    }
+}
+
+void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+    int contourCount = shape.contours.size();
+    int w = output.width(), h = output.height();
+    
+    WindingSpanner spanner;
+    std::vector<int> windings;
+    windings.reserve(contourCount);
+    for (std::vector<Contour>::const_iterator contour = shape.contours.begin(); contour != shape.contours.end(); ++contour)
+        windings.push_back(contour->winding());
+    
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp parallel
+#endif
+    {
+        std::vector<MultiDistance> contourSD;
+        contourSD.resize(contourCount);
+#ifdef MSDFGEN_USE_OPENMP
+#pragma omp for
+#endif
+        for (int y = 0; y < h; ++y) {
+            int row = shape.inverseYAxis ? h-y-1 : y;
+            
+            // Start slightly off the -X edge so we ensure we find all spans.
+            spanner.collect(shape, Vector2(-0.5, y + 0.5)/scale - translate);
+            
+            for (int x = 0; x < w; ++x) {
+                Point2 p = Vector2(x+.5, y+.5)/scale-translate;
+                
+                struct EdgePoint {
+                    SignedDistance minDistance;
+                    const EdgeHolder *nearEdge;
+                    double nearParam;
+                } sr, sg, sb;
+                sr.nearEdge = sg.nearEdge = sb.nearEdge = NULL;
+                sr.nearParam = sg.nearParam = sb.nearParam = 0;
+                int realSign = spanner.advanceTo(p.x);
+                
+                std::vector<Contour>::const_iterator contour = shape.contours.begin();
+                for (int i = 0; i < contourCount; ++i, ++contour) {
+                    EdgePoint r, g, b;
+                    r.nearEdge = g.nearEdge = b.nearEdge = NULL;
+                    r.nearParam = g.nearParam = b.nearParam = 0;
+                    
+                    for (std::vector<EdgeHolder>::const_iterator edge = contour->edges.begin(); edge != contour->edges.end(); ++edge) {
+                        
+                        double param;
+                        SignedDistance distance = (*edge)->signedDistance(p, param);
+                        if ((*edge)->color&RED && distance < r.minDistance) {
+                            r.minDistance = distance;
+                            r.nearEdge = &*edge;
+                            r.nearParam = param;
+                        }
+                        if ((*edge)->color&GREEN && distance < g.minDistance) {
+                            g.minDistance = distance;
+                            g.nearEdge = &*edge;
+                            g.nearParam = param;
+                        }
+                        if ((*edge)->color&BLUE && distance < b.minDistance) {
+                            b.minDistance = distance;
+                            b.nearEdge = &*edge;
+                            b.nearParam = param;
+                        }
+                    }
+                    
+                    if (r.minDistance < sr.minDistance) {
+                        sr = r;
+                    }
+                    if (g.minDistance < sg.minDistance) {
+                        sg = g;
+                    }
+                    if (b.minDistance < sb.minDistance) {
+                        sb = b;
+                    }
+                }
+                if (sr.nearEdge)
+                    (*sr.nearEdge)->distanceToPseudoDistance(sr.minDistance, p, sr.nearParam);
+                if (sg.nearEdge)
+                    (*sg.nearEdge)->distanceToPseudoDistance(sg.minDistance, p, sg.nearParam);
+                if (sb.nearEdge)
+                    (*sb.nearEdge)->distanceToPseudoDistance(sb.minDistance, p, sb.nearParam);
+
+                float dr = sr.minDistance.distance;
+                float dg = sg.minDistance.distance;
+                float db = sb.minDistance.distance;
+                
+                double med = median(dr, dg, db);
+                // Note: Use signbit() not sign() here because we need to know -0 case.
+                int medSign = signbit(med) ? -1 : 1;
+
+                if( medSign != realSign ) {
+                    dr = -dr;
+                    dg = -dg;
+                    db = -db;
+                }
+                
+                output(x, row).r = float(dr/range+.5);
+                output(x, row).g = float(dg/range+.5);
+                output(x, row).b = float(db/range+.5);
+            }
+        }
+    }
+    
+    if (edgeThreshold > 0)
+        msdfErrorCorrection(output, edgeThreshold/(scale*range));
+}
+    
+    
+
+void generateSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
     int contourCount = shape.contours.size();
     int w = output.width(), h = output.height();
     std::vector<int> windings;
@@ -127,7 +393,7 @@ void generateSDF(Bitmap<float> &output, const Shape &shape, double range, const 
     }
 }
 
-void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+void generatePseudoSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
     int contourCount = shape.contours.size();
     int w = output.width(), h = output.height();
     std::vector<int> windings;
@@ -204,7 +470,7 @@ void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, 
     }
 }
 
-void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+void generateMSDF_v2(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
     int contourCount = shape.contours.size();
     int w = output.width(), h = output.height();
     std::vector<int> windings;
@@ -333,7 +599,7 @@ void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, co
         msdfErrorCorrection(output, edgeThreshold/(scale*range));
 }
 
-void generateSDF_legacy(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+void generateSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
     int w = output.width(), h = output.height();
 #ifdef MSDFGEN_USE_OPENMP
     #pragma omp parallel for
@@ -355,7 +621,7 @@ void generateSDF_legacy(Bitmap<float> &output, const Shape &shape, double range,
     }
 }
 
-void generatePseudoSDF_legacy(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
+void generatePseudoSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate) {
     int w = output.width(), h = output.height();
 #ifdef MSDFGEN_USE_OPENMP
     #pragma omp parallel for
@@ -384,7 +650,7 @@ void generatePseudoSDF_legacy(Bitmap<float> &output, const Shape &shape, double 
     }
 }
 
-void generateMSDF_legacy(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
+void generateMSDF_v1(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold) {
     int w = output.width(), h = output.height();
 #ifdef MSDFGEN_USE_OPENMP
     #pragma omp parallel for

--- a/main.cpp
+++ b/main.cpp
@@ -450,7 +450,7 @@ int main(int argc, const char * const *argv) {
             if( argPos+1 < argc && parseUnsigned(legacyMode, argv[argPos]) ) {
                 argPos += 1;
             }
-            if (legacyMode < 0 || legacyMode > 2) {
+            if (legacyMode > 2) {
                 ABORT("Invalid legacy mode");
             }
             

--- a/msdfgen.h
+++ b/msdfgen.h
@@ -38,8 +38,13 @@ void generatePseudoSDF(Bitmap<float> &output, const Shape &shape, double range, 
 void generateMSDF(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold = 1.00000001);
 
 // Original simpler versions of the previous functions, which work well under normal circumstances, but cannot deal with overlapping contours.
-void generateSDF_legacy(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
-void generatePseudoSDF_legacy(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
-void generateMSDF_legacy(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold = 1.00000001);
+void generateSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
+void generatePseudoSDF_v1(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
+void generateMSDF_v1(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold = 1.00000001);
+
+// Pre-fill-rule versions.
+void generateSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
+void generatePseudoSDF_v2(Bitmap<float> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate);
+void generateMSDF_v2(Bitmap<FloatRGB> &output, const Shape &shape, double range, const Vector2 &scale, const Vector2 &translate, double edgeThreshold = 1.00000001);
 
 }


### PR DESCRIPTION
This implements SVG/TTF/Postscript style fill rule support.

Rather than replace the existing method, I have left it in as a legacy option as that seems to be your preferred method of dealing with this. However, it seems like if we stay that course, we're going to get a fair amount of old code to maintain. My preference would be to just replace it and if people want older versions, they can check out via source control and build it themselves.

If you merge https://github.com/Chlumsky/msdfgen/pull/48 you can see the test cases I've been using for verification (including the basic examples as part of the SVG spec):

![montage-msdf-0-render](https://user-images.githubusercontent.com/826657/26952419-3c64dc34-4c5a-11e7-9f10-a86b2843f98a.png)

(This image was generated using the fixes in the point_tolerance PR (https://github.com/Chlumsky/msdfgen/pull/41), which is why the map looks correct.)
