### PR TITLE
Adding a fix to readNoteType so it properly advances the string

### DIFF
--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -24,10 +24,12 @@ namespace msdfgen {
 static bool readNodeType(char &output, const char *&pathDef) {
     int shift;
     char nodeType;
-    if (sscanf(pathDef, " %c%n", &nodeType, &shift) == 1 && nodeType != '+' && nodeType != '-' && nodeType != '.' && nodeType != ',' && (nodeType < '0' || nodeType > '9')) {
+    if (sscanf(pathDef, " %c%n", &nodeType, &shift) == 1) {
         pathDef += shift;
-        output = nodeType;
-        return true;
+		if (nodeType != '+' && nodeType != '-' && nodeType != '.' && nodeType != ',' && (nodeType < '0' || nodeType > '9')) {
+			output = nodeType;
+			return true;
+		}
     }
     return false;
 }


### PR DESCRIPTION
Adding a fix to readNoteType so it properly advances the string when it didn't read a new command char and reruns the same command.

Was having a problem where some of my svgs weren't loading.

I have confirmed this is the right behavior from here:

https://www.w3.org/TR/SVG2/paths.html

"The command letter can be eliminated on subsequent commands if the same command is used multiple times in a row (e.g., you can drop the second "L" in "M 100 200 L 200 100 L -100 -200" and use "M 100 200 L 200 100 -100 -200" instead)."