### PR TITLE
Fix compile issues on GCC

### DIFF
--- a/core/msdf-edge-artifact-patcher.cpp
+++ b/core/msdf-edge-artifact-patcher.cpp
@@ -1,6 +1,7 @@
 
 #include "msdf-edge-artifact-patcher.h"
 
+#include <cstring>
 #include <vector>
 #include <utility>
 #include "arithmetics.hpp"
@@ -131,7 +132,7 @@ static void msdfPatchEdgeArtifactsInner(const BitmapRef<float, N> &sdf, const Sh
         // Store hotspot's closest texel's current color
         float *subject = sdf((int) hotspot->x, (int) hotspot->y);
         float texel[N];
-        memcpy(texel, subject, N*sizeof(float));
+        std::memcpy(texel, subject, N*sizeof(float));
         // Sample signed distance at hotspot
         float msd[N];
         interpolate(msd, BitmapConstRef<float, N>(sdf), *hotspot);
@@ -143,7 +144,7 @@ static void msdfPatchEdgeArtifactsInner(const BitmapRef<float, N> &sdf, const Sh
         interpolate(msd, BitmapConstRef<float, N>(sdf), *hotspot);
         float newSsd = median(msd[0], msd[1], msd[2]);
         // Revert modified texel
-        memcpy(subject, texel, N*sizeof(float));
+        std::memcpy(subject, texel, N*sizeof(float));
 
         // Consider hotspot an artifact if flattening improved the sample
         if (fabsf(newSsd-sd) < fabsf(oldSsd-sd))


### PR DESCRIPTION
Fix for #111. For whatever reason, your current includes don't bring `memcpy` in (I'm guessing it has to do with how whatever STL implementation I'm using is structured). I opted for the C++ version, but I can replace `#include <cstring>` with `#include <string.h>` and it will also solve the problem, while also allowing removal of the `std::` prefixes on each call. Let me know what you think!

Really awesome piece of code, it's proving very useful in my project. Thanks!