### PR TITLE
Fix pragma(lib, ...) conflicting with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+target_compile_definitions(msdfgen-ext PUBLIC MSDFGEN_CMAKE_BUILD)
+
 if(MSDFGEN_USE_CPP11)
 	target_compile_features(msdfgen-ext PUBLIC cxx_std_11)
 	target_compile_definitions(msdfgen-ext PUBLIC MSDFGEN_USE_CPP11)

--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -7,7 +7,7 @@
 #include FT_FREETYPE_H
 #include FT_OUTLINE_H
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(MSDFGEN_CMAKE_BUILD)
     #pragma comment(lib, "freetype.lib")
 #endif
 

--- a/ext/resolve-shape-geometry.cpp
+++ b/ext/resolve-shape-geometry.cpp
@@ -9,7 +9,7 @@
 #include "../core/edge-segments.h"
 #include "../core/Contour.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(MSDFGEN_CMAKE_BUILD)
     #pragma comment(lib, "skia.lib")
 #endif
 


### PR DESCRIPTION
The visual studio build seems to use these pragma's to link to the freetype/skia binaries in the source tree, which can cause conflicts when running a cmake build on windows if cmake finds freetype/skia lib files with slightly different names, e.g. libfreetyped.lib, because in this case linking against msdfgen causes "freetype.lib not found" linker errors due to the pragma's even though cmake is correctly linking against the lib files it found.

To fix this issue I've added a simple macro-def to flag when cmake is being used so the pragma's can be disabled when building with cmake (which handles finding the libraries itself) but remain active when using the .sln file.

I've tested building with both cmake and the visual studio project in debug and release on linux and windows and these changes seem to fix any issues without breaking things.