### PR TITLE
Feature/github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: msdfgen Build
+
+on:
+  workflow_dispatch:
+    inputs:
+  push:
+    branches:
+      - master
+      - feature/gh-actions
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    outputs:
+      RELEASE_TAG_VERSION: ${{ steps.release_prep.outputs.RELEASE_TAG_VERSION }}
+      IS_RELEASE_TAG: ${{ steps.release_prep.outputs.IS_RELEASE_TAG }}
+    strategy:
+      fail-fast: false
+      matrix: 
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+      # Install necessary dependencies for build
+    - name: Install dependencies
+      run: |
+        ./dependencies.sh
+      shell: bash
+      working-directory: scripts
+      # Actual building
+    - name: Build
+      run: |
+        ./build.sh
+      working-directory: ./scripts
+      shell: bash
+      # Upload build artifacts
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: |
+          bin/complete/*.tar.gz
+          bin/complete/*.zip
+      # Check whether release job needs to run, and with which release tag
+    - name: Prepare for Release
+      id: release_prep
+      # Only release when the current commit is tagged
+      run: |
+        git describe --exact-match --tags HEAD 2> /dev/null &&  IS_RELEASE_TAG=True
+        RELEASE_TAG_VERSION=$(git describe --tag)
+        
+        echo "::set-output name=RELEASE_TAG_VERSION::$RELEASE_TAG_VERSION"
+        echo "::set-output name=IS_RELEASE_TAG::$IS_RELEASE_TAG"
+        
+      shell: bash
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifacts
+        path: artifacts
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      if: needs.build.outputs.IS_RELEASE_TAG=='True'
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false
+        automatic_release_tag: "${{ needs.build.outputs.RELEASE_TAG_VERSION }}"
+        files: |
+          artifacts/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    outputs:
-      RELEASE_TAG_VERSION: ${{ steps.release_prep.outputs.RELEASE_TAG_VERSION }}
-      IS_RELEASE_TAG: ${{ steps.release_prep.outputs.IS_RELEASE_TAG }}
     strategy:
-      fail-fast: false
       matrix: 
         os: [ubuntu-latest, windows-latest, macos-latest]
 
@@ -39,31 +35,51 @@ jobs:
         path: |
           bin/complete/*.tar.gz
           bin/complete/*.zip
-      # Check whether release job needs to run, and with which release tag
-    - name: Prepare for Release
-      id: release_prep
-      # Only release when the current commit is tagged
-      run: |
-        git describe --exact-match --tags HEAD 2> /dev/null &&  IS_RELEASE_TAG=True
-        RELEASE_TAG_VERSION=$(git describe --tag)
-        
-        echo "::set-output name=RELEASE_TAG_VERSION::$RELEASE_TAG_VERSION"
-        echo "::set-output name=IS_RELEASE_TAG::$IS_RELEASE_TAG"
-        
-      shell: bash
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - uses: actions/checkout@v1
+    - name: Prepare repository name
+      run: |
+        echo "REPOSITORY_OWNER=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
+        echo "REPOSITORY_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+    - name: Get Latest Release Info
+      id: latest_version
+      uses: abatilo/release-info-action@v1.3.0
+      with:
+        owner: ${{ env.REPOSITORY_OWNER }}
+        repo: ${{ env.REPOSITORY_NAME }}
+      # Check whether release job needs to run, and with which release tag
+    - name: Prepare for Release
+      id: release_prep
+      env:
+        PREVIOUS_RELEASE_TAG: ${{ steps.latest_version.outputs.latest_tag }}
+      # Only release when the current commit is tagged
+      run: |
+        ./scripts/release_info.sh
+      shell: bash
     - uses: actions/download-artifact@v2
+      if: steps.release_prep.outputs.IS_RELEASE=='True'
       with:
         name: artifacts
         path: artifacts
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      if: needs.build.outputs.IS_RELEASE_TAG=='True'
+    - name: Create Release
+      id: create_release
+      if: steps.release_prep.outputs.IS_RELEASE=='True'
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: v${{ steps.release_prep.outputs.RELEASE_VERSION }}
+        release_name: Version ${{ steps.release_prep.outputs.RELEASE_VERSION }}
+        body: ${{ steps.release_prep.outputs.RELEASE_CHANGELOG }}
+        draft: false
         prerelease: false
-        automatic_release_tag: "${{ needs.build.outputs.RELEASE_TAG_VERSION }}"
-        files: |
-          artifacts/*
+    - name: Upload Assets to Release
+      if: steps.release_prep.outputs.IS_RELEASE=='True'
+      uses: csexton/release-asset-action@v2
+      with:
+        pattern: "artifacts/*"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        release-url: ${{ steps.create_release.outputs.upload_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.VC.opendb
 *.VC.db
 /bin/*.lib
+/bin/**/*
 output.png
 render.png
 out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ option(MSDFGEN_USE_SKIA "Build with the Skia library" OFF)
 option(FREETYPE_WITH_PNG "Link libpng and zlib because FreeType is configured to require it" OFF)
 option(FREETYPE_WITH_HARFBUZZ "Link HarfBuzz because FreeType is configured to require it" OFF)
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/tools/vcpkg/scripts/buildsystems/vcpkg.cmake")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/scripts/tools/vcpkg/scripts/buildsystems/vcpkg.cmake")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(Freetype REQUIRED)
@@ -59,6 +63,10 @@ target_include_directories(msdfgen INTERFACE
 	$<INSTALL_INTERFACE:include>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
 )
+# Optimize size of binaries
+if (NOT WIN32 AND NOT APPLE)
+  set_target_properties(msdfgen PROPERTIES LINK_FLAGS_RELEASE "${LINK_FLAGS_RELEASE} -s")
+endif()
 
 if(MSDFGEN_USE_CPP11)
 	target_compile_features(msdfgen PUBLIC cxx_std_11)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+source ./platform_detect.sh
+
+cd ../bin
+# Create build subdirectories
+mkdir minimal 2> /dev/null | true
+mkdir minimal32 2> /dev/null | true
+mkdir openmp 2> /dev/null | true
+mkdir openmp32 2> /dev/null | true
+mkdir complete 2> /dev/null | true
+
+version=$(git describe --tags) # Get version name from current git tag
+executable_suffix=""
+
+
+use_32_bit=false # Per default do not build 32 bit
+
+case $platform_suffix in
+    "win")
+        use_32_bit=true # Build 32 bit as well for windows
+        executable_suffix=".exe" # windows has .exe as executable suffix
+        ;;
+esac
+
+Build() {
+    Arch="$1"
+    Configuration="$2"
+    
+    OUTPUT_NAME="msdf-${Configuration}-${version}-${platform_suffix}-${Arch}"
+    BUILD_DIR_PREFIX="."
+    
+    Generator="Unix Makefiles" # Default to unix makefiles
+    case $platform_suffix in
+        "win") 
+            case $Arch in
+                "x64") GeneratorArch="-A x64" ;;
+                "x86") GeneratorArch="-A Win32" ;;
+            esac
+            BUILD_DIR_PREFIX="Release" # VS builds put output files in a $Configuration sub directory
+            Generator="Visual Studio 16"
+            ;;
+        "linux")
+            case $Arch in
+                "x64") GeneratorArch="-m 64" ;;
+                "x86") GeneratorArch="-m 32" ;;
+            esac
+            ;;
+    esac
+    case $Configuration in
+        "minimal") PARAMS="" ;; # No additional settings
+        "openmp") PARAMS="-DMSDFGEN_USE_OPENMP=ON" ;; # Enable openmp in build
+    esac
+    # Conigure build
+    cmake -DCMAKE_BUILD_TYPE=Release -G "$Generator" $GeneratorArch ../.. -DMSDFGEN_USE_CPP11=ON -DMSDFGEN_BUILD_MSDFGEN_STANDALONE=ON $PARAMS || return $?
+    # Build
+    cmake --build . --config Release -j 4 || return $?
+    # Create collected output directory for easy archiving
+    mkdir ../complete/$OUTPUT_NAME/ 2> /dev/null | true
+    cp $BUILD_DIR_PREFIX/msdfgen$executable_suffix ../complete/$OUTPUT_NAME/
+    case $platform_suffix in
+    "win")
+        # Archive with powershell into zip
+        powershell "Compress-Archive ../complete/$OUTPUT_NAME/* ../complete/$OUTPUT_NAME.zip" || return $?
+        ;;
+    *) # Default to tar.gz
+        pushd ../complete/$OUTPUT_NAME
+        tar -zcvf ../$OUTPUT_NAME.tar.gz * || return $?
+        popd
+        ;;
+    esac
+}
+
+#Minimal builds
+
+cd minimal
+Build "x64" "minimal" || exit $?
+cd ..
+
+if [ "$use_32_bit" = true ] ; then
+    cd minimal32
+    Build "x86" "minimal" || exit $?
+    cd ..
+fi
+
+# OpenMP builds
+
+cd openmp
+Build "x64" "openmp" || exit $?
+cd ..
+
+if [ "$use_32_bit" = true ] ; then
+    cd openmp32
+    Build "x86" "openmp" || exit $?
+    cd ..
+fi

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source ./platform_detect.sh
+case $platform_suffix in
+    "win")
+        mkdir tools
+        cd tools
+        git clone https://github.com/microsoft/vcpkg
+        ./vcpkg/bootstrap-vcpkg.bat
+
+
+        vcpkg/vcpkg install freetype
+        vcpkg/vcpkg install freetype:x64-windows
+        vcpkg/vcpkg integrate install
+        ;;
+    "mac")
+        brew install libomp
+        ;;
+esac

--- a/scripts/platform_detect.sh
+++ b/scripts/platform_detect.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Detect current build platform
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    platform_suffix="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    platform_suffix="mac"
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+    platform_suffix="win"
+elif [[ "$OSTYPE" == "msys" ]]; then
+    platform_suffix="win"
+elif [[ "$OSTYPE" == "win32" ]]; then
+    platform_suffix="win"
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+    platform_suffix="freebsd"
+else
+    echo "Unknown operating system: $OSTYPE"
+    exit 1
+fi

--- a/scripts/release_info.sh
+++ b/scripts/release_info.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+CHANGELOG_FILE=CHANGELOG.md
+
+read_changelog_latest_version() {
+    VERSION_LINE=$(grep -m 1 "^##" $CHANGELOG_FILE | grep -Po '#*\sVersion\s\K.*')
+    VERSION_DATE=$(echo $VERSION_LINE | grep -Po '.*\s\(\K.*(?=\))')
+    VERSION=$(echo $VERSION_LINE | grep -Po '[a-zA-Z0-9\.]*(?=\s.*)')
+    
+    echo "$VERSION"
+}
+
+read_changelog_body() {
+   read -d '' -a VERSION_LINE_NUMBERS < <(grep -n -P "^##.*" $CHANGELOG_FILE | head -n 2 | cut -f1 -d:)
+   PREVIOUS_VERSION_LINE_NUMBER=${VERSION_LINE_NUMBERS[1]}
+   CURRENT_VERSION_LINE_NUMBER=${VERSION_LINE_NUMBERS[0]}
+   
+   CHANGELOG_BODY=$(cat $CHANGELOG_FILE | tail -n +$(($CURRENT_VERSION_LINE_NUMBER+1)) | head -n $(($PREVIOUS_VERSION_LINE_NUMBER - $CURRENT_VERSION_LINE_NUMBER - 1)))
+   
+   CHANGELOG_BODY=$(sed -e '/./,$!d' -e :a -e '/^\n*$/{$d;N;ba' -e '}' <<< $CHANGELOG_BODY) # Remove leading and trailing empty lines
+   echo "$CHANGELOG_BODY"
+}
+
+PREVIOUS_RELEASE_COMMIT=$(git rev-list -n 1 tags/$PREVIOUS_RELEASE_TAG)
+
+# For testing PREVIOUS_RELEASE_COMMIT=5427fe8f5a427e1baa1e6fb7d5d8cf938362765c
+
+CHANGELOG_CHANGE_COMMIT=$(git log $PREVIOUS_RELEASE_COMMIT^...HEAD --pretty=%H -- $CHANGELOG_FILE)
+CHANGELOG_CHANGE_COMMIT=${CHANGELOG_CHANGE_COMMIT##*$'\n'} # Is mostly gonna be equal to PREVIOUS_RELEASE_COMMIT
+
+echo "Previous release commit: $CHANGELOG_CHANGE_COMMIT"
+
+if [ -z "$CHANGELOG_CHANGE_COMMIT" ]
+then
+    echo "No changes made to Changelog file: '$CHANGELOG_FILE' since latest release '$PREVIOUS_RELEASE_COMMIT'"
+    exit
+fi
+# Revert changelog file to get previous version info
+git checkout $CHANGELOG_CHANGE_COMMIT $CHANGELOG_FILE 2> /dev/null || exit $?
+
+PREVIOUS_VERSION=$(read_changelog_latest_version)
+
+# Restore original changelog file
+git restore --staged $CHANGELOG_FILE 2> /dev/null || exit $?
+git restore $CHANGELOG_FILE 2> /dev/null || exit $?
+
+
+CURRENT_VERSION=$(read_changelog_latest_version)
+
+if [ "$PREVIOUS_VERSION" == "$CURRENT_VERSION" ];
+then
+    echo "Version number did not change"
+    exit
+fi
+
+
+CHANGELOG_BODY=$(read_changelog_body)
+
+echo "Body:"
+echo "$CHANGELOG_BODY"
+CHANGELOG_BODY_ESCAPED="${CHANGELOG_BODY//'%'/'%25'}"
+CHANGELOG_BODY_ESCAPED="${CHANGELOG_BODY_ESCAPED//$'\n'/'%0A'}"
+CHANGELOG_BODY_ESCAPED="${CHANGELOG_BODY_ESCAPED//$'\r'/'%0D'}"
+
+echo "###############################################"
+
+echo "::set-output name=RELEASE_VERSION::$CURRENT_VERSION"
+echo "::set-output name=RELEASE_CHANGELOG::$CHANGELOG_BODY_ESCAPED"
+echo "::set-output name=IS_RELEASE::True"


### PR DESCRIPTION
Hello,
I added github actions to be able to build and release continuously.
The action builds for every commit on master(and on the feature/gh-actions branch - can be removed if so desired).
Building happens on Windows, Linux and MacOS currently only the created executable files are added to archives(zip for win, tar.gz for everything else). These archives are uploaded as github action artifacts and can be downloaded from there, but gh-actions build artifacts are only temporary and are going to be deleted at some point, still imho a good thing to be able to download non release versions beforehand.
Additionally I added a script which should detect version changes to the CHANGELOG.md file and if a new version is detected a new release is automatically created using the changelog body and version.

Edit: I did btw. test it on my fork and it seemed to work like intended, no promises though :D

Hope this can help for future releases.

(Btw. I did do all that work because I want to do changes to be able to create a shared library for usage from other languages) 