### PR TITLE
CMake: fix install target for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(MSDFGEN_INSTALL)
     )
 
     if(MSDFGEN_BUILD_MSDFGEN_STANDALONE)
-        install(TARGETS msdfgen-standalone EXPORT msdfgenTargets RUNTIME DESTINATION bin)
+        install(TARGETS msdfgen-standalone EXPORT msdfgenTargets DESTINATION bin)
     endif()
 
     install(


### PR DESCRIPTION
Since https://cmake.org/cmake/help/latest/policy/CMP0006.html, bundles targets must have BUNDLE DESTINATION, otherwise configuration fails. By removing RUNTIME, it sets DESTINATION for all types.