### PR TITLE
Expose svg-import.buildFromPath().

### DIFF
--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -129,7 +129,7 @@ static void addArcApproximate(Contour &contour, Point2 startPoint, Point2 endPoi
     }
 }
 
-static bool buildFromPath(Shape &shape, const char *pathDef, double size) {
+bool buildFromPath(Shape &shape, const char *pathDef, double size) {
     char nodeType = '\0';
     char prevNodeType = '\0';
     Point2 prevNode(0, 0);

--- a/ext/import-svg.h
+++ b/ext/import-svg.h
@@ -9,4 +9,5 @@ namespace msdfgen {
 /// Reads the first path found in the specified SVG file and stores it as a Shape in output.
 bool loadSvgShape(Shape &output, const char *filename, int pathIndex = 0, Vector2 *dimensions = NULL);
 
+bool buildFromPath(Shape &shape, const char *pathDef, double size);
 }


### PR DESCRIPTION
Since SVG support is limited and in fact msdfgen requires single path description from whole SVG file it would be nice to have library api to take this description exactly. In this case instead of writing SVG transformator-preparator script one can write wrapper to support whole range of cases he needs.
(I’m working on svg support for https://github.com/Yanrishatum/fontgen and this commit allows me to extract required path in haxe and pass it to msdfgen)