### PR TITLE
Allow command line interface to accept glyph #0 as input

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -88,10 +88,6 @@ unsigned GlyphIndex::getIndex() const {
     return index;
 }
 
-bool GlyphIndex::operator!() const {
-    return index == 0;
-}
-
 FreetypeHandle * initializeFreetype() {
     FreetypeHandle *handle = new FreetypeHandle;
     FT_Error error = FT_Init_FreeType(&handle->library);

--- a/ext/import-font.h
+++ b/ext/import-font.h
@@ -17,7 +17,6 @@ class GlyphIndex {
 public:
     explicit GlyphIndex(unsigned index = 0);
     unsigned getIndex() const;
-    bool operator!() const;
 
 private:
     unsigned index;

--- a/main.cpp
+++ b/main.cpp
@@ -503,9 +503,10 @@ int main(int argc, const char * const *argv) {
             unsigned gi;
             switch (charArg[0]) {
                 case 'G': case 'g':
-                    if (parseUnsignedDecOrHex(gi, charArg+1))
+                    if (parseUnsignedDecOrHex(gi, charArg+1)) {
                         glyphIndex = GlyphIndex(gi);
                         glyphIndexSpecified = true;
+                    }
                     break;
                 case 'U': case 'u':
                     ++charArg;

--- a/main.cpp
+++ b/main.cpp
@@ -442,6 +442,7 @@ int main(int argc, const char * const *argv) {
     const char *testRender = NULL;
     const char *testRenderMulti = NULL;
     bool outputSpecified = false;
+    bool glyphIndexSpecified = false;
     GlyphIndex glyphIndex;
     unicode_t unicode = 0;
     int svgPathIndex = 0;
@@ -504,6 +505,7 @@ int main(int argc, const char * const *argv) {
                 case 'G': case 'g':
                     if (parseUnsignedDecOrHex(gi, charArg+1))
                         glyphIndex = GlyphIndex(gi);
+                        glyphIndexSpecified = true;
                     break;
                 case 'U': case 'u':
                     ++charArg;
@@ -838,7 +840,7 @@ int main(int argc, const char * const *argv) {
             break;
         }
         case FONT: {
-            if (!glyphIndex && !unicode)
+            if (!glyphIndexSpecified && !unicode)
                 ABORT("No character specified! Use -font <file.ttf/otf> <character code>. Character code can be a Unicode index (65, 0x41), a character in apostrophes ('A'), or a glyph index prefixed by g (g36, g0x24).");
             FreetypeHandle *ft = initializeFreetype();
             if (!ft) return -1;


### PR DESCRIPTION
Fixes #148

I also removed the `!` operator from `GlyphIndex` because
+ It's meaningless and misleading;
+ The rest of the codebase doesn't seem to use that operator.

Since there's no unit tests I couldn't run one.

I was greeted with some weird debug assertion failure dialogs when calling the new binaries from my homemade asset pipeline, but the result looks fine (kind of) so maybe that wasn't my patch's fault:
![FiraSans-Bold otf](https://user-images.githubusercontent.com/12986688/162307163-22d50f5d-0e30-498d-8e26-7030e2bb1ab2.png)

