### PR TITLE
Add an option to dump colored edges as an SVG file.

### DIFF
--- a/core/edge-segments.cpp
+++ b/core/edge-segments.cpp
@@ -3,8 +3,22 @@
 
 #include "arithmetics.hpp"
 #include "equation-solver.h"
+#include <sstream>
 
 namespace msdfgen {
+
+static std::string colorStr(EdgeColor c) {
+    switch ( c) {
+        case BLACK: return "black";
+        case RED: return "red";
+        case GREEN: return "green";
+        case YELLOW: return "yellow";
+        case BLUE: return "blue";
+        case MAGENTA: return "magenta";
+        case CYAN: return "cyan";
+        case WHITE: return "white";
+    }
+}
 
 void EdgeSegment::distanceToPseudoDistance(SignedDistance &distance, Point2 origin, double param) const {
     if (param < 0) {
@@ -37,12 +51,25 @@ LinearSegment::LinearSegment(Point2 p0, Point2 p1, EdgeColor edgeColor) : EdgeSe
     p[1] = p1;
 }
 
+std::string LinearSegment::svg(float scale) const {
+    std::stringstream ss;
+    ss<< "<path d=\"" << "M"<<(p[0].x*scale)<<","<<(p[0].y*scale)<<" L" << (p[1].x*scale)<<","<<(p[1].y*scale) << "\" stroke=\"" << colorStr(this->color) << "\" />";
+    return ss.str();
+}
+
 QuadraticSegment::QuadraticSegment(Point2 p0, Point2 p1, Point2 p2, EdgeColor edgeColor) : EdgeSegment(edgeColor) {
     if (p1 == p0 || p1 == p2)
         p1 = 0.5*(p0+p2);
     p[0] = p0;
     p[1] = p1;
     p[2] = p2;
+}
+
+std::string QuadraticSegment::svg(float scale) const {
+    std::stringstream ss;
+    ss << "<path d=\""
+       << "M" << (p[0].x*scale) << "," << (p[0].y*scale) << " Q" << (p[1].x*scale) << "," << (p[1].y*scale) << " " << (p[2].x*scale) << "," << (p[2].y*scale) << "\" stroke=\"" << colorStr(this->color) << "\" />";
+    return ss.str();
 }
 
 CubicSegment::CubicSegment(Point2 p0, Point2 p1, Point2 p2, Point2 p3, EdgeColor edgeColor) : EdgeSegment(edgeColor) {
@@ -54,6 +81,13 @@ CubicSegment::CubicSegment(Point2 p0, Point2 p1, Point2 p2, Point2 p3, EdgeColor
     p[1] = p1;
     p[2] = p2;
     p[3] = p3;
+}
+
+std::string CubicSegment::svg(float scale) const {
+    std::stringstream ss;
+    ss << "<path d=\""
+       << "M" << (p[0].x*scale) << "," << (p[0].y*scale) << " C" << (p[1].x*scale) << "," << (p[1].y*scale) << " " << (p[2].x*scale) << "," << (p[2].y*scale) << " " << (p[3].x*scale) << ","<<(p[3].y*scale) << "\" stroke=\"" << colorStr(this->color) << "\" />";
+    return ss.str();
 }
 
 LinearSegment * LinearSegment::clone() const {

--- a/core/edge-segments.h
+++ b/core/edge-segments.h
@@ -4,6 +4,7 @@
 #include "Vector2.h"
 #include "SignedDistance.h"
 #include "EdgeColor.h"
+#include <string>
 
 namespace msdfgen {
 
@@ -44,7 +45,8 @@ public:
     virtual void moveEndPoint(Point2 to) = 0;
     /// Splits the edge segments into thirds which together represent the original edge.
     virtual void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const = 0;
-
+    
+    virtual std::string svg(float scale) const = 0;
 };
 
 /// A line segment.
@@ -67,7 +69,7 @@ public:
     void moveStartPoint(Point2 to);
     void moveEndPoint(Point2 to);
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
-
+    std::string svg(float scale) const;
 };
 
 /// A quadratic Bezier curve.
@@ -92,7 +94,7 @@ public:
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
     EdgeSegment * convertToCubic() const;
-
+    std::string svg(float scale) const;
 };
 
 /// A cubic Bezier curve.
@@ -116,7 +118,7 @@ public:
     void splitInThirds(EdgeSegment *&part1, EdgeSegment *&part2, EdgeSegment *&part3) const;
 
     void deconverge(int param, double amount);
-
+    std::string svg(float scale) const;
 };
 
 }


### PR DESCRIPTION
I had a hard time understanding the paper. I'm now trying to debug the code to understand it. In particular, I don't quite get the logic of switchColor(). 

And for example, what are those hardcoded values:

```cpp
for (int i = 0; i < m; ++i)
                    contour->edges[(corner+i)%m]->color = (colors+1)[int(3+2.875*i/(m-1)-1.4375+.5)-3];
```

I hope to add a new option: dumping colored edges as an SVG file. So we can visualize them. 

```
-outputedgecolor <filename.svg> <width> <height> <scale>
```