### PR TITLE
Adding setVariationAxis for variable fonts

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -21,6 +21,7 @@ class FreetypeHandle {
     friend FontHandle * loadFont(FreetypeHandle *library, const char *filename);
     friend FontHandle * loadFontData(FreetypeHandle *library, const byte *data, int length);
     friend bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *axisname, double coordinate);
+    friend bool getVariationAxes(std::vector<FontVariationAxis> &axes, FontHandle *font, FreetypeHandle *library);
 
     FT_Library library;
 
@@ -39,6 +40,7 @@ class FontHandle {
     friend bool getKerning(double &output, FontHandle *font, GlyphIndex glyphIndex1, GlyphIndex glyphIndex2);
     friend bool getKerning(double &output, FontHandle *font, unicode_t unicode1, unicode_t unicode2);
     friend bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *axisname, double coordinate);
+    friend bool getVariationAxes(std::vector<FontVariationAxis> &axes, FontHandle *font, FreetypeHandle *library);
 
     FT_Face face;
     bool ownership;
@@ -242,6 +244,26 @@ bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *nam
         FT_Done_MM_Var(library->library, amaster);
     }
     return success;
+}
+
+bool getVariationAxes(std::vector<FontVariationAxis> &axes, FontHandle *font, FreetypeHandle *library) {
+    if (font->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+        FT_MM_Var *amaster;
+        FT_Get_MM_Var(font->face, &amaster);
+
+        for (FT_UInt i = 0; i < amaster->num_axis; i++) {
+            FontVariationAxis axis{
+                amaster->axis[i].name,
+                F16DOT16_TO_DOUBLE(amaster->axis[i].minimum),
+                F16DOT16_TO_DOUBLE(amaster->axis[i].def),
+                F16DOT16_TO_DOUBLE(amaster->axis[i].maximum)
+            };
+            axes.push_back(axis);
+        }
+        FT_Done_MM_Var(library->library, amaster);
+        return true;
+    }
+    return false;
 }
 
 }

--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -12,6 +12,8 @@ namespace msdfgen {
 
 #define REQUIRE(cond) { if (!(cond)) return false; }
 #define F26DOT6_TO_DOUBLE(x) (1/64.*double(x))
+#define DOUBLE_TO_F16DOT16(x)  (FT_Fixed(x*65536.))
+#define F16DOT16_TO_DOUBLE(x)  (1/65536.*double(x))
 
 class FreetypeHandle {
     friend FreetypeHandle * initializeFreetype();
@@ -231,8 +233,9 @@ bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *nam
         for (FT_UInt i = 0; i < amaster->num_axis; i++) {
             int strdiff = strcmp(name,amaster->axis[i].name);
             if (strdiff == 0) {
-                coords[i] = (int)(coordinate * 65536.0);
+                coords[i] = DOUBLE_TO_F16DOT16(coordinate);
                 success = true;
+                break;
             }
         }
         FT_Set_Var_Design_Coordinates(font->face, coords.size(), coords.data());

--- a/ext/import-font.h
+++ b/ext/import-font.h
@@ -62,5 +62,7 @@ bool loadGlyph(Shape &output, FontHandle *font, unicode_t unicode, double *advan
 /// Outputs the kerning distance adjustment between two specific glyphs.
 bool getKerning(double &output, FontHandle *font, GlyphIndex glyphIndex1, GlyphIndex glyphIndex2);
 bool getKerning(double &output, FontHandle *font, unicode_t unicode1, unicode_t unicode2);
+/// Sets variation axis of variable font.
+bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *name, double coordinate);
 
 }

--- a/ext/import-font.h
+++ b/ext/import-font.h
@@ -35,6 +35,18 @@ struct FontMetrics {
     double underlineY, underlineThickness;
 };
 
+/// A structure to model a given axis for variation fonts.
+struct FontVariationAxis {
+    /// The name of the variation axis.
+    const char * name;
+    /// The axis's minimum design coordinate.
+    double minimum;
+    /// The axis's default design coordinate. FreeType computes meaningful default values for Adobe MM fonts.
+    double def;
+    /// The axis's maximum design coordinate.
+    double maximum;
+};
+
 /// Initializes the FreeType library.
 FreetypeHandle * initializeFreetype();
 /// Deinitializes the FreeType library.
@@ -64,5 +76,6 @@ bool getKerning(double &output, FontHandle *font, GlyphIndex glyphIndex1, GlyphI
 bool getKerning(double &output, FontHandle *font, unicode_t unicode1, unicode_t unicode2);
 /// Sets variation axis of variable font.
 bool setVariationAxis(FontHandle *font, FreetypeHandle *library, const char *name, double coordinate);
+bool getVariationAxes(std::vector<FontVariationAxis> &axes, FontHandle *font, FreetypeHandle *library);
 
 }


### PR DESCRIPTION
Hey,
first pull request here, I hope there is interest and I'm doing this right.

A very basic implementation of variable font axes.
slightly inspired by [godot](https://github.com/godotengine/godot/blob/master/modules/text_server_fb/text_server_fb.cpp) and [freetype docs](https://freetype.org/freetype2/docs/reference/ft2-multiple_masters.html).

There is a second pull request with a cli implementation for the main.cpp application in the making.
