### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ there is a Windows binary available for download in the ["Releases" section](htt
 To build the project, you may use the included [Visual Studio solution](Msdfgen.sln)
 or [CMake script](CMakeLists.txt).
 
+### Installing from vcpkg
+
+You can download and install `msdfgen` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+./vcpkg integrate install
+./vcpkg install msdfgen
+```
+The `msdfgen` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Console commands
 
 The standalone program is executed as


### PR DESCRIPTION
`msdfgen` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `msdfgen` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `msdfgen`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/msdfgen/portfile.cmake). We try to keep the library maintained as close as possible to the original library.