### PR TITLE
Minor header-files includes cleanup

### DIFF
--- a/core/EdgeHolder.cpp
+++ b/core/EdgeHolder.cpp
@@ -1,6 +1,8 @@
 
 #include "EdgeHolder.h"
 
+#include <cstddef> // for NULL
+
 namespace msdfgen {
 
 void EdgeHolder::swap(EdgeHolder &a, EdgeHolder &b) {

--- a/core/Vector2.cpp
+++ b/core/Vector2.cpp
@@ -1,6 +1,8 @@
 
 #include "Vector2.h"
 
+#include <cmath> // for sqrt(), atan2()
+
 namespace msdfgen {
 
 Vector2::Vector2(double val) : x(val), y(val) { }

--- a/core/Vector2.h
+++ b/core/Vector2.h
@@ -1,9 +1,6 @@
 
 #pragma once
 
-#include <cstdlib>
-#include <cmath>
-
 namespace msdfgen {
 
 /**

--- a/core/generator-config.h
+++ b/core/generator-config.h
@@ -1,8 +1,7 @@
 
 #pragma once
 
-#include <cstdlib>
-#include "BitmapRef.hpp"
+#include "BitmapRef.hpp" // for msdfgen::byte
 
 #ifndef MSDFGEN_PUBLIC
 #define MSDFGEN_PUBLIC // for DLL import/export

--- a/core/shape-description.h
+++ b/core/shape-description.h
@@ -1,8 +1,7 @@
 
 #pragma once
 
-#include <cstdlib>
-#include <cstdio>
+#include <cstdio> // for FILE
 #include "Shape.h"
 
 namespace msdfgen {


### PR DESCRIPTION
Some includes not used directly in header-files and 'pollute' namespace, that's why they moved into source-files.
- `<cmath>` in `Vector2.h` moved into `Vector2.cpp`
- `<cstdlib>` not used in `Vector2.h`, but after removing, `<cstddef>` needed in `EdgeHolder.cpp`
- Unused `<cstdlib> removed from `generator-config.h` and `shape-description.h`

Changes tested during compiling "core-only" library with `gcc 11.3.0` 