### PR TITLE
Update edge-coloring.cpp - added include <cstdlib>, since we use 'qsort()' func from it

### DIFF
--- a/core/edge-coloring.cpp
+++ b/core/edge-coloring.cpp
@@ -1,6 +1,7 @@
 
 #include "edge-coloring.h"
 
+#include <cstdlib> // for: qsort()
 #include <cmath>
 #include <cstring>
 #include <cfloat>


### PR DESCRIPTION
Greetings! 

During compilation of current 'master' branch with (pretty old, huh) `gcc (Debian 4.9.2-10) 4.9.2` compiler produced the next error:
```
/msdfgen-master/core/edge-coloring.cpp: In function ‘void msdfgen::edgeColoringByDistance(msdfgen::Shape&, double, long long unsigned int)’:
/msdfgen-master/core/edge-coloring.cpp:469:103: error: ‘qsort’ was not declared in this scope
         qsort(&graphEdgeDistances[0], graphEdgeDistances.size(), sizeof(const double *), &cmpDoublePtr);
                                                                                                       ^
```

cppreference [say](https://en.cppreference.com/w/cpp/algorithm/qsort), that `qsort()` declared in `<cstdlib>`. After adding that include, the whole library compiled successfuly - no other places to fix :)

This PR fixes this error above :)