### PR TITLE
Prevent multiple defined _CRT_SECURE_NO_WARNINGS macro

### DIFF
--- a/core/save-bmp.cpp
+++ b/core/save-bmp.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-bmp.h"
 

--- a/core/save-tiff.cpp
+++ b/core/save-tiff.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-tiff.h"
 

--- a/core/shape-description.cpp
+++ b/core/shape-description.cpp
@@ -1,5 +1,8 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "shape-description.h"
 
 #include <cstdlib>

--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -1,6 +1,10 @@
 
 #define _USE_MATH_DEFINES
+
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "import-svg.h"
 
 #ifndef MSDFGEN_DISABLE_SVG

--- a/ext/save-png.cpp
+++ b/ext/save-png.cpp
@@ -1,5 +1,8 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "save-png.h"
 
 #include <cstdio>

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,11 @@
 #ifdef MSDFGEN_STANDALONE
 
 #define _USE_MATH_DEFINES
+
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <cstdlib>
 #include <cstdio>
 #include <cmath>


### PR DESCRIPTION
Prevent MSVC warning C4005 for macro redefinition.