### PR TITLE
explicit loading of .notdef glyph is now possible

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -223,6 +223,10 @@ bool getGlyphCount(unsigned &output, FontHandle *font) {
 
 bool getGlyphIndex(GlyphIndex &glyphIndex, FontHandle *font, unicode_t unicode) {
     glyphIndex = GlyphIndex(FT_Get_Char_Index(font->face, unicode));
+	if (unicode == 0)
+	{
+		return true;
+	}
     return glyphIndex.getIndex() != 0;
 }
 


### PR DESCRIPTION
Being able to load the \.notdef glyph (often mapped from codepoint 0 or used as a fallback) is important for several reasons:
- Fallback rendering for unsupported characters
- Robust text layout