### PR TITLE
font outlines: support for turning the stroked outline of a TTF font into a shape for MSDF processing

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -6,6 +6,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_OUTLINE_H
+#include FT_STROKER_H
 #ifndef MSDFGEN_DISABLE_VARIABLE_FONTS
 #include FT_MULTIPLE_MASTERS_H
 #endif
@@ -40,6 +41,8 @@ class FontHandle {
     friend bool getGlyphIndex(GlyphIndex &glyphIndex, FontHandle *font, unicode_t unicode);
     friend bool loadGlyph(Shape &output, FontHandle *font, GlyphIndex glyphIndex, FontCoordinateScaling coordinateScaling, double *outAdvance);
     friend bool loadGlyph(Shape &output, FontHandle *font, unicode_t unicode, FontCoordinateScaling coordinateScaling, double *outAdvance);
+    friend bool loadGlyphOutline(Shape &output, FontHandle *font, GlyphIndex glyphIndex, double border, FontCoordinateScaling coordinateScaling, double *outAdvance);
+    friend bool loadGlyphOutline(Shape &output, FontHandle *font, unicode_t unicode, double border, FontCoordinateScaling coordinateScaling, double *outAdvance);
     friend bool getKerning(double &output, FontHandle *font, GlyphIndex glyphIndex0, GlyphIndex glyphIndex1, FontCoordinateScaling coordinateScaling);
     friend bool getKerning(double &output, FontHandle *font, unicode_t unicode0, unicode_t unicode1, FontCoordinateScaling coordinateScaling);
 #ifndef MSDFGEN_DISABLE_VARIABLE_FONTS
@@ -238,8 +241,56 @@ bool loadGlyph(Shape &output, FontHandle *font, GlyphIndex glyphIndex, FontCoord
     return !readFreetypeOutline(output, &font->face->glyph->outline, scale);
 }
 
+bool loadGlyphOutline(Shape &output, FontHandle *font, GlyphIndex glyphIndex, double border, FontCoordinateScaling coordinateScaling, double *outAdvance) {
+    if (!font)
+        return false;
+        
+    FT_Error error = FT_Load_Glyph(font->face, glyphIndex.getIndex(), FT_LOAD_NO_SCALE);
+    if (error)
+        return false;
+
+    double scale = getFontCoordinateScale(font->face, coordinateScaling);
+    if (outAdvance)
+        *outAdvance = scale*font->face->glyph->advance.x;
+
+	FT_GlyphSlot	glyph = font->face->glyph;
+	FT_Glyph 		outline_glyph;
+	FT_Stroker 		stroker;
+
+	error = FT_Get_Glyph(glyph, &outline_glyph);
+    if (error)
+        return false;
+
+	error = FT_Stroker_New(font->face->glyph->library, &stroker);
+    if (error)
+    {
+		FT_Done_Glyph(outline_glyph);
+        return false;
+	}
+	
+	FT_Stroker_Set(stroker, border, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
+	error = FT_Glyph_Stroke(&outline_glyph, stroker, 1);
+	FT_Stroker_Done(stroker);
+
+	if (error || outline_glyph->format != FT_GLYPH_FORMAT_OUTLINE)
+	{
+		FT_Done_Glyph(outline_glyph);
+		return false;
+	}
+		
+    FT_Outline* outline = &reinterpret_cast<FT_OutlineGlyph>(outline_glyph)->outline;
+    // You now have the FT_Outline* to the stroked glyph data
+	bool retVal = !readFreetypeOutline(output, outline, scale);
+	FT_Done_Glyph(outline_glyph);
+	return retVal;
+}
+
 bool loadGlyph(Shape &output, FontHandle *font, unicode_t unicode, FontCoordinateScaling coordinateScaling, double *outAdvance) {
     return loadGlyph(output, font, GlyphIndex(FT_Get_Char_Index(font->face, unicode)), coordinateScaling, outAdvance);
+}
+
+bool loadGlyphOutline(Shape &output, FontHandle *font, unicode_t unicode, double border, FontCoordinateScaling coordinateScaling, double *outAdvance) {
+    return loadGlyphOutline(output, font, GlyphIndex(FT_Get_Char_Index(font->face, unicode)), border, coordinateScaling, outAdvance);
 }
 
 bool loadGlyph(Shape &output, FontHandle *font, GlyphIndex glyphIndex, double *outAdvance) {

--- a/ext/import-font.h
+++ b/ext/import-font.h
@@ -86,6 +86,9 @@ bool getGlyphIndex(GlyphIndex &glyphIndex, FontHandle *font, unicode_t unicode);
 /// Loads the geometry of a glyph from a font.
 bool loadGlyph(Shape &output, FontHandle *font, GlyphIndex glyphIndex, FontCoordinateScaling coordinateScaling, double *outAdvance = NULL);
 bool loadGlyph(Shape &output, FontHandle *font, unicode_t unicode, FontCoordinateScaling coordinateScaling, double *outAdvance = NULL);
+/// Loads the geometry of a glyph from a font but with the outline of the glyph filled in, not the entire glyph.
+bool loadGlyphOutline(Shape &output, FontHandle *font, GlyphIndex glyphIndex, double border, FontCoordinateScaling coordinateScaling, double *outAdvance = NULL);
+bool loadGlyphOutline(Shape &output, FontHandle *font, unicode_t unicode, double border, FontCoordinateScaling coordinateScaling, double *outAdvance = NULL);
 // Legacy API - FontCoordinateScaling is LEGACY
 bool loadGlyph(Shape &output, FontHandle *font, GlyphIndex glyphIndex, double *outAdvance = NULL);
 bool loadGlyph(Shape &output, FontHandle *font, unicode_t unicode, double *outAdvance = NULL);

--- a/main.cpp
+++ b/main.cpp
@@ -576,6 +576,7 @@ int main(int argc, const char *const *argv) {
     GlyphIndex glyphIndex;
     unicode_t unicode = 0;
     FontCoordinateScaling fontCoordinateScaling = FONT_SCALING_LEGACY;
+    double border = 0;
     bool fontCoordinateScalingSpecified = false;
 #endif
 
@@ -661,6 +662,12 @@ int main(int argc, const char *const *argv) {
             }
             continue;
         }
+        if (argPos+2 < argc && !strcmp(arg,"-border"))
+        {
+			++argPos;
+			border = atoi(argv[argPos++]);
+			continue;
+		}
         ARG_CASE("-noemnormalize", 0) {
             fontCoordinateScaling = FONT_SCALING_NONE;
             fontCoordinateScalingSpecified = true;
@@ -1063,8 +1070,16 @@ int main(int argc, const char *const *argv) {
                 ABORT("Failed to load font file.");
             if (unicode)
                 getGlyphIndex(glyphIndex, guard.font, unicode);
-            if (!loadGlyph(shape, guard.font, glyphIndex, fontCoordinateScaling, &glyphAdvance))
-                ABORT("Failed to load glyph from font file.");
+			if(border > 0)
+			{
+				if (!loadGlyphOutline(shape, guard.font, glyphIndex, border, fontCoordinateScaling, &glyphAdvance))
+					ABORT("Failed to load glyph from font file.");
+			}
+			else
+			{
+				if (!loadGlyph(shape, guard.font, glyphIndex, fontCoordinateScaling, &glyphAdvance))
+					ABORT("Failed to load glyph from font file.");
+			}
             if (!fontCoordinateScalingSpecified && (!autoFrame || scaleSpecified || rangeMode == RANGE_UNIT || mode == METRICS || printMetrics || shapeExport || svgExport)) {
                 fputs(
                     "Warning: Using legacy font coordinate conversion for compatibility reasons.\n"


### PR DESCRIPTION
In order to provide a thick "inked in" outline around a large font, an MSDF font has to use a range of distance fields values to make the transition area (from inside to outside of the font glyph) visible. While this works, the line quality is not great; an outlined period does not have a consistent "stroke" around the outside of the period.

This PR addresses this by providing a new pair of functions that converts a TTF glyph to a shape by first stroking it using FT. The stroker will form new contours a set offset from the old contours that can then be visualized.

To test, run the command-line tool on a font glyph but add a -border flag. For example, -border 16 works well with a glyph dimension of 128x128, and a pxrange of 16.

In general, stroked glyphs need a larger MSDF size than a filled glyph because the features are smaller.